### PR TITLE
Added a fix for CPLEX and gurobi overlap check

### DIFF
--- a/R/JaBbA.R
+++ b/R/JaBbA.R
@@ -55,8 +55,13 @@ low.count=high.count=seg=chromosome=alpha_high=alpha_low=beta_high=beta_low=pred
         jmessage("${CPLEX_DIR}/cplex/[(include)|(lib)] do not both exist")
     }
 
-    library(gGnome)
-    gGnome:::testOptimizationFunction()
+    if (!requireNamespace("gurobi", quietly = TRUE)) {
+        jmessage("Gurobi is not installed! REMEMBER: You need to have either CPLEX or Gurobi!")
+        
+    } else {
+        library(gGnome)
+        gGnome:::testOptimizationFunction()
+    } 
 
     invisible()
 }


### PR DESCRIPTION
**Description:**
Added quick fix for CPLEX check when gurobi is loaded

**Changes:**

- Bypasses the CPLEX gGnome check if gurobi is loaded, else will check CPLEX for gGnome

