### PR TITLE
Fixing a bug where the CPLEX check was forcefully implemented even when using Gurobi

### DIFF
--- a/R/JaBbA.R
+++ b/R/JaBbA.R
@@ -55,13 +55,28 @@ low.count=high.count=seg=chromosome=alpha_high=alpha_low=beta_high=beta_low=pred
         jmessage("${CPLEX_DIR}/cplex/[(include)|(lib)] do not both exist")
     }
 
-    if (!requireNamespace("gurobi", quietly = TRUE)) {
-        jmessage("Gurobi is not installed! REMEMBER: You need to have either CPLEX or Gurobi!")
+    if (((!file.exists(paste0(cplex.dir, "/cplex"))) & (!file.exists(paste0(cplex.dir, "/cplex/include")) ||
+               !file.exists(paste0(cplex.dir, "/cplex/lib")))) & (requireNamespace("gurobi", quietly = TRUE))) {
+        jmessage("Gurobi is installed! Will use Gurobi instead of CPLEX if mentioned use.gurobi=TRUE")
         
-    } else {
+    } else if (((file.exists(paste0(cplex.dir, "/cplex"))) & (file.exists(paste0(cplex.dir, "/cplex/include")) ||
+               file.exists(paste0(cplex.dir, "/cplex/lib")))) & (!requireNamespace("gurobi", quietly = TRUE))) {
+
+	jmessage("CPLEX found, will check if gGnome is wired up with CPLEX...")
         library(gGnome)
         gGnome:::testOptimizationFunction()
-    } 
+
+    } else if (((file.exists(paste0(cplex.dir, "/cplex"))) & (file.exists(paste0(cplex.dir, "/cplex/include")) ||
+               file.exists(paste0(cplex.dir, "/cplex/lib")))) & (requireNamespace("gurobi", quietly = TRUE))) {
+
+	jmessage("Both CPLEX and Gurobi is found, will check if gGnome has CPLEX wired since by default JaBbA use CPLEX...")
+	library(gGnome)
+	gGnome:::testOptimizationFunction()
+	
+    } else {
+
+	jmessage("Both CPLEX and Gurobi not found! REMEMBER: You need any one of these optimizers to run JaBbA")
+    }
 
     invisible()
 }

--- a/R/JaBbA.R
+++ b/R/JaBbA.R
@@ -55,8 +55,13 @@ low.count=high.count=seg=chromosome=alpha_high=alpha_low=beta_high=beta_low=pred
         jmessage("${CPLEX_DIR}/cplex/[(include)|(lib)] do not both exist")
     }
 
-    library(gGnome)
-    gGnome:::testOptimizationFunction()
+    if (!requireNamespace("gurobi", quietly = TRUE)) {
+        jmessage("Gurobi is not installed! REMEMBER: You need to have either CPLEX or Gurobi!")
+        
+    } else {
+        library(gGnome)
+        gGnome:::testOptimizationFunction()
+    } 
 
     invisible()
 }

--- a/R/JaBbA.R
+++ b/R/JaBbA.R
@@ -54,20 +54,24 @@ low.count=high.count=seg=chromosome=alpha_high=alpha_low=beta_high=beta_low=pred
                !file.exists(paste0(cplex.dir, "/cplex/lib"))){
         jmessage("${CPLEX_DIR}/cplex/[(include)|(lib)] do not both exist")
     }
+    
+    # variable that stores checks for CPLEX directory and its lib & include folder
+    cplex_installation = ((file.exists(paste0(cplex.dir, "/cplex"))) & (file.exists(paste0(cplex.dir, "/cplex/include")) ||
+               file.exists(paste0(cplex.dir, "/cplex/lib"))))
+    # variable that stores boolean information for Gurobi installation
+    gurobi_installation = (requireNamespace("gurobi", quietly = TRUE))
 
-    if (((!file.exists(paste0(cplex.dir, "/cplex"))) & (!file.exists(paste0(cplex.dir, "/cplex/include")) ||
-               !file.exists(paste0(cplex.dir, "/cplex/lib")))) & (requireNamespace("gurobi", quietly = TRUE))) {
+    # check to verify whether gurobi or cplex or both or none. if cplex or both cplex and gurobi found, it will run cplex connection for gGnome package
+    if ((!cplex_installation) & (gurobi_installation)) {
         jmessage("Gurobi is installed! Will use Gurobi instead of CPLEX if mentioned use.gurobi=TRUE")
         
-    } else if (((file.exists(paste0(cplex.dir, "/cplex"))) & (file.exists(paste0(cplex.dir, "/cplex/include")) ||
-               file.exists(paste0(cplex.dir, "/cplex/lib")))) & (!requireNamespace("gurobi", quietly = TRUE))) {
+    } else if ((cplex_installation) & (!gurobi_installation)) {
 
 	jmessage("CPLEX found, will check if gGnome is wired up with CPLEX...")
         library(gGnome)
         gGnome:::testOptimizationFunction()
 
-    } else if (((file.exists(paste0(cplex.dir, "/cplex"))) & (file.exists(paste0(cplex.dir, "/cplex/include")) ||
-               file.exists(paste0(cplex.dir, "/cplex/lib")))) & (requireNamespace("gurobi", quietly = TRUE))) {
+    } else if ((cplex_installation) & (gurobi_installation)) {
 
 	jmessage("Both CPLEX and Gurobi is found, will check if gGnome has CPLEX wired since by default JaBbA use CPLEX...")
 	library(gGnome)


### PR DESCRIPTION

**Description:**
- Addresses the issue where CPLEX check was ran even with Gurobi being used

**Changes:**
- added independent checks so that if gurobi is loaded, it will not run CPLEX check.
- if Cplex is present, but not gurobi, it will run CPLEX check for gGnome. If both gurobi and cplex is present, it will still run CPLEX check because by default JaBbA uses CPLEX unless otherwise mentioned gurobi.

**Impact:**
- Should address the issue where users were facing issues installing JaBbA when gurobi was being used as optimizer instead of CPLEX.